### PR TITLE
Bugfix/search multiple visits

### DIFF
--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types"
 import { StaticQuery, graphql } from "gatsby"
 import HelloWorker from '../workers/hello.worker.js'
 
-const SEO = ({ title, description, image, pathname, article }) => (
+const SEO = ({ title, description, image, pathname, article, track }) => (
   <StaticQuery
     query={query}
     render={({
@@ -20,7 +20,8 @@ const SEO = ({ title, description, image, pathname, article }) => (
         },
       },
     }) => {
-      if (typeof window === 'object') {
+      const recordVisit = track === 'NO' ? false : true
+      if (typeof window === 'object' && recordVisit) {
         const helloWorker = new HelloWorker()
         helloWorker.postMessage([window.location.href, document.referrer])
       }

--- a/src/components/search-input.js
+++ b/src/components/search-input.js
@@ -7,23 +7,29 @@ const ENTER_KEY_CODE = 13;
 
 const SearchInput = () => {
 
-  function debounce(func, duration) {
-    let timeout
-    return function (...args) {
-      const effect = () => {
-        timeout = null
-        return func.apply(this, args)
-      }
-      clearTimeout(timeout)
-      timeout = setTimeout(effect, duration)
-    }
-  }
+  // function debounce(func, duration) {
+  //   let timeout
+  //   return function (...args) {
+  //     const effect = () => {
+  //       timeout = null
+  //       return func.apply(this, args)
+  //     }
+  //     clearTimeout(timeout)
+  //     timeout = setTimeout(effect, duration)
+  //   }
+  // }
 
-  const search = debounce((charCode, text) => {
+  // const search = debounce((charCode, text) => {
+  //   if (charCode === ENTER_KEY_CODE) {
+  //     navigate(`/search-results/?q=${text}`);
+  //   }
+  // }, 300);
+
+  function search (charCode, text) {
     if (charCode === ENTER_KEY_CODE) {
       navigate(`/search-results/?q=${text}`);
     }
-  }, 300);
+  }
 
   return (
     <div className={styles.wrapper}>

--- a/src/pages/search-results.js
+++ b/src/pages/search-results.js
@@ -53,7 +53,7 @@ const SearchResults = () => {
 
   return (
     <Layout>
-      <SEO title="Search Results" pathname="/search-results" />
+      <SEO title="Search Results" pathname="/search-results" track="NO" />
       { renderHelper() }
       <AllLink marginTop="30px" />
     </Layout>

--- a/src/pages/search-results.js
+++ b/src/pages/search-results.js
@@ -15,6 +15,7 @@ const SearchResults = () => {
   const searchTerm = query.q
   const [list, setList] = useState([]);
   const [searching, setSearching] = useState(true)
+  const [track, setTrack] = useState('NO')
 
   useEffect(() => {
     async function fetchData() {
@@ -23,6 +24,8 @@ const SearchResults = () => {
       const searchResults = await getSearchResults(searchTerm);
       setList(searchResults);
       setSearching(false)
+      setTrack('YES')
+      setTrack('NO')
     }
     fetchData();
   }, [searchTerm]);
@@ -53,7 +56,7 @@ const SearchResults = () => {
 
   return (
     <Layout>
-      <SEO title="Search Results" pathname="/search-results" track="NO" />
+      <SEO title="Search Results" pathname="/search-results" track={track} />
       { renderHelper() }
       <AllLink marginTop="30px" />
     </Layout>


### PR DESCRIPTION
User landing on search results page was causing 4 visits to be recorded. This is caused by updating state in async `useEffect` handler, which triggers a re-render, which causes SEO component to be re-rendered, which has the track visitor call. Fix is to also have a `track` state, pass as a new prop to SEO, which will use it to control if visit gets tracked.